### PR TITLE
Typo TX_FLAMEEYES_...  vs. TX.FLAMEEYES_...

### DIFF
--- a/rules/flameeyes_60_fake_browsers.conf
+++ b/rules/flameeyes_60_fake_browsers.conf
@@ -219,7 +219,7 @@ SecRule TX:FLAMEEYES_GECKO_APP "^$" \
 # If the Gecko app detected is Firefox, make sure to set the
 # FF_VERSION the same, to simplify later rules.
 SecRule TX:FLAMEEYES_GECKO_APP "@streq Firefox" \
-	"id:436203,phase:2,nolog,setvar:TX_FLAMEEYES_GECKO_FF_VERSION=%{TX.FLAMEEYES_GECKO_APP_VERSION}"
+	"id:436203,phase:2,nolog,setvar:TX.FLAMEEYES_GECKO_FF_VERSION=%{TX.FLAMEEYES_GECKO_APP_VERSION}"
 
 # Even though Mozilla says that, on Desktop, the Gecko Trail is a
 # fixed string of 20100101, that's no longer true with Firefox Aurora


### PR DESCRIPTION
Fixes warning: Asked to set variable "TX_FLAMEEYES_GECKO_FF_VERSION", but no collection name specified.
